### PR TITLE
Libuuid destdir

### DIFF
--- a/External_libuuid.cmake.in
+++ b/External_libuuid.cmake.in
@@ -21,8 +21,19 @@ ExternalProject_Add(libuuid
     SOURCE_DIR ${EP_SOURCE_DIR}
     BINARY_DIR ${EP_BINARY_DIR}
     INSTALL_DIR ${EP_INSTALL_DIR}
-    CONFIGURE_COMMAND bash configure --prefix=${EP_INSTALL_DIR} --disable-all-programs --enable-libuuid
+    CONFIGURE_COMMAND bash configure --disable-all-programs --enable-libuuid
     BUILD_COMMAND make
-    INSTALL_COMMAND make install
+    # On some platforms:
+    # - If `DESTDIR` is not specified with the install command, libuuid will be
+    # installed in a system prefix.
+    # - If `DESTDIR` is specified and `prefix` is not, the makefile inserts a
+    # `usr` in the library install path.
+    # - If `DESTDIR` and `prefix` are both set to the installation prefix, the
+    # header install path is a concatenation of `DESTDIR` and `prefix`,
+    # repeating the installation prefix.
+    #
+    # The solution appears to set `prefix` to an empty string and `DESTDIR` to
+    # the installation prefix.
+    INSTALL_COMMAND make install prefix="" DESTDIR=${EP_INSTALL_DIR}
 )
 


### PR DESCRIPTION
In the current state of master, trying to build locally gives

```
make[4]: Leaving directory '/home/sylvain/dev/jupyter-xeus/xeus-python-wheel/_skbuild/linux-x86_64-3.7/cmake-build/libuuid-download/libuuid-src'
 /bin/mkdir -p '/usr/share/bash-completion/completions'
 /usr/bin/install -c -m 644 bash-completion/uuidgen '/usr/share/bash-completion/completions'
/usr/bin/install: cannot remove '/usr/share/bash-completion/completions/uuidgen': Permission denied
```

That is because on linux, although having a --prefix set at the configure stage, tries to install to a system path.

Cf https://github.com/spack/spack/issues/7632 by @ax3l..

The fix appears to be setting `prefix=` and `DESTDIR=`  at make install time.

1. Setting both these values to the full path of the installation prefix results in the library being installed at the right location but headers being installed in `Full-prefix/Full-prefix/include/uuid`...

2. Setting only `prefix` does not fix the issue

3. Setting only `DESTDIR` almost does it, but somehow, the library is installed in `PREFIX/usr/lib`, i.e. a `usr` is inserted somehow.

4.This sets `DESTDIR` to the installation prefix and `prefix` to an empty string.
