### PR TITLE
Enable debugger in kernel configuration.

### DIFF
--- a/kernels/xpython/kernel.json.in
+++ b/kernels/xpython/kernel.json.in
@@ -7,5 +7,6 @@
       "-f",
       "{connection_file}"
   ],
-  "language": "python"
+  "language": "python",
+  "metadata": { "debugger": true }
 }


### PR DESCRIPTION
This enables the debugger in built versions of the wheel. It works in my Ubuntu environment but I'm not sure if there may be other issues that caused the debug flag to be intentionally turned off. 