### PR TITLE
Update scikit-build

### DIFF
--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Setup xcode
       uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: '10.3'
+        xcode-version: '11'
 
     - name: Build wheel
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
   "setuptools",
   "wheel",
-  "scikit-build>=0.11.0,<0.12",
+  "scikit-build>=0.11.0,<0.14",
   "cmake",
   "ninja"
 ]


### PR DESCRIPTION
- There has been a couple of versions since 0.11.
- 0.12 and 0.13 are built as noarch on conda-forge, which makes it possible to install them in py3.10 environments, and build xeus-python-static for python 3.10.