### PR TITLE
Use a valid SPDX identifier as license classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
     version=xeus_version,
     description='A wheel for xeus-python',
     author='Sylvain Corlay, Johan Mabille, Martin Renou',
-    license='',
+    license='BSD-3-Clause',
     packages=['xpython'],
     py_modules=['xpython_launcher'],
     install_requires=[


### PR DESCRIPTION
This helps automatic license checkers like pip-licenses to identify the right license for this project