### PR TITLE
Update to currently supported Python versions

### DIFF
--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -60,7 +60,7 @@ jobs:
 
     - uses: actions/upload-artifact@v4
       with:
-        name: wheelhouse
+        name: wheelhouse-macos-${{ matrix.PYTHON_VERSION }}
         path: wheelhouse/xeus_python-*.whl
         if-no-files-found: error
 
@@ -96,7 +96,7 @@ jobs:
 
     - uses: actions/upload-artifact@v4
       with:
-        name: wheelhouse
+        name: wheelhouse-linux-${{ matrix.PYTHON_VERSION }}
         path: ${{ env.WHEEL }}
 
   windows:
@@ -130,7 +130,7 @@ jobs:
 
     - uses: actions/upload-artifact@v4
       with:
-        name: wheelhouse
+        name: wheelhouse-win-${{ matrix.PYTHON_VERSION }}
         path: wheelhouse/xeus_python-*.whl
         if-no-files-found: error
 

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -196,7 +196,8 @@ jobs:
 
     - uses: actions/download-artifact@v4
       with:
-        name: wheelhouse
+        pattern: wheelhouse-*
+        merge-multiple: true
         path: ./wheelhouse
 
     - name: Install Python
@@ -232,13 +233,14 @@ jobs:
 
     - uses: actions/download-artifact@v4
       with:
-        name: wheelhouse
+        pattern: wheelhouse-*
+        merge-multiple: true
         path: ./wheelhouse
 
     - name: Install Python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: 3.13
 
     - name: Install deps
       run: python -m pip install twine

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Install Python
       uses: actions/setup-python@v4
@@ -58,7 +58,7 @@ jobs:
     - name: List wheels
       run: ls wheelhouse
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: wheelhouse
         path: wheelhouse/xeus_python-*.whl
@@ -77,7 +77,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Build wheel
       run: |
@@ -94,7 +94,7 @@ jobs:
     - name: Get wheel name
       run: echo "WHEEL=$(find wheelhouse -type f -iname 'xeus_python-*.whl')" >> $GITHUB_ENV
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: wheelhouse
         path: ${{ env.WHEEL }}
@@ -109,7 +109,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Install Python
       uses: actions/setup-python@v4
@@ -128,7 +128,7 @@ jobs:
     - name: List wheels
       run: ls wheelhouse
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: wheelhouse
         path: wheelhouse/xeus_python-*.whl
@@ -192,9 +192,9 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: wheelhouse
         path: ./wheelhouse
@@ -230,7 +230,7 @@ jobs:
 
     steps:
 
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: wheelhouse
         path: ./wheelhouse

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        PYTHON_VERSION: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        PYTHON_VERSION: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         ARCH: ["x86_64", "arm64"]
 
     env:
@@ -70,7 +70,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        PYTHON_VERSION: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        PYTHON_VERSION: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     container:
         image: "quay.io/pypa/manylinux2014_x86_64"
@@ -105,7 +105,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        PYTHON_VERSION: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        PYTHON_VERSION: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - name: Checkout
@@ -142,14 +142,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos, windows]
-        PYTHON_VERSION: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        PYTHON_VERSION: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         include:
-          - PYTHON_VERSION: "3.7"
-            os: ubuntu
-            whl: 'xeus_python-*-cp37*linux*.whl'
-          - PYTHON_VERSION: "3.8"
-            os: ubuntu
-            whl: 'xeus_python-*-cp38*linux*.whl'
           - PYTHON_VERSION: "3.9"
             os: ubuntu
             whl: 'xeus_python-*-cp39*linux*.whl'
@@ -162,12 +156,9 @@ jobs:
           - PYTHON_VERSION: "3.12"
             os: ubuntu
             whl: 'xeus_python-*-cp312*linux*.whl'
-          - PYTHON_VERSION: "3.7"
-            os: macos
-            whl: 'xeus_python-*-cp37*macos*x86_64.whl'
-          - PYTHON_VERSION: "3.8"
-            os: macos
-            whl: 'xeus_python-*-cp38*macos*x86_64.whl'
+          - PYTHON_VERSION: "3.13"
+            os: ubuntu
+            whl: 'xeus_python-*-cp313*linux*.whl'
           - PYTHON_VERSION: "3.9"
             os: macos
             whl: 'xeus_python-*-cp39*macos*x86_64.whl'
@@ -180,12 +171,9 @@ jobs:
           - PYTHON_VERSION: "3.12"
             os: macos
             whl: 'xeus_python-*-cp312*macos*x86_64.whl'
-          - PYTHON_VERSION: "3.7"
-            os: windows
-            whl: 'xeus_python-*-cp37*win*.whl'
-          - PYTHON_VERSION: "3.8"
-            os: windows
-            whl: 'xeus_python-*-cp38*win*.whl'
+          - PYTHON_VERSION: "3.13"
+            os: macos
+            whl: 'xeus_python-*-cp313*macos*x86_64.whl'
           - PYTHON_VERSION: "3.9"
             os: windows
             whl: 'xeus_python-*-cp39*win*.whl'
@@ -198,6 +186,9 @@ jobs:
           - PYTHON_VERSION: "3.12"
             os: windows
             whl: 'xeus_python-*-cp312*win*.whl'
+          - PYTHON_VERSION: "3.13"
+            os: windows
+            whl: 'xeus_python-*-cp313*win*.whl'
 
     steps:
     - name: Checkout

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
   "setuptools~=69.0",
   "wheel",
   "scikit-build>=0.11.0,<0.14",
-  "cmake<3.5",
+  "cmake<3.28.1",
   "ninja",
   "packaging<22"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-  "setuptools",
+  "setuptools~=69.0",
   "wheel",
   "scikit-build>=0.11.0,<0.14",
   "cmake>=3.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
   "setuptools~=69.0",
   "wheel",
   "scikit-build>=0.11.0,<0.14",
-  "cmake>=3.4",
+  "cmake<3.5",
   "ninja",
   "packaging<22"
 ]


### PR DESCRIPTION
Removes 3.7 and 3.8 that are EOL, and adds 3.13.

Fixes #120 and #121 

Closes #114